### PR TITLE
i2cdev: adapt regex to only match bus devices

### DIFF
--- a/interfaces/i2cdev/main.py
+++ b/interfaces/i2cdev/main.py
@@ -24,7 +24,7 @@ class I2C(InterfaceBase):
             raise FileNotFoundError("I2C device directory not found")
         dev_dict = {}
         for dev in dev_list:
-            match = re.match("i2c-.*", dev)
+            match = re.match("i2c-\d+", dev)
             if match:
                 num = int(re.sub("i2c-", "", dev))
                 with open("/sys/bus/i2c/devices/"+match.string+"/name", 'r') as fname:


### PR DESCRIPTION
Currently, the regex used for matching I2C bus devices also matches I2C devices like i2c-FTCS1000:00. Adapt the regex accordingly.